### PR TITLE
feat(sensor): Added sensor hal modules

### DIFF
--- a/core/inc/sensor_hal.h
+++ b/core/inc/sensor_hal.h
@@ -1,0 +1,205 @@
+/**
+ * @file    sensor_hal.h
+ * @brief   Sensor Hardware Abstraction Layer — public interface
+ *
+ * @details This module provides a clean interface for reading all physical
+ *          sensors connected to the EV ECU. It abstracts the STM32 ADC,
+ *          GPIO, and Timer peripherals so that higher-level modules
+ *          (fault manager, state machine, logger) never call HAL directly.
+ *
+ *          Sensors managed by this module:
+ *            - Battery temperature  (ADC channel 0, PA0, LM35)
+ *            - Motor temperature    (ADC channel 1, PA1, LM35)
+ *            - Battery current      (ADC channel 2, PA2, ACS712-20A)
+ *            - Battery voltage      (ADC channel 3, PA3, resistor divider)
+ *            - Throttle position    (ADC channel 4, PA4, potentiometer)
+ *            - Motor speed          (TIM3 encoder mode, PA6/PA7)
+ *            - Brake switch         (GPIO PB0, active-low)
+ *            - Fault trigger switch (GPIO PB1, active-low)
+ *
+ *          Usage example:
+ *          @code
+ *            sensor_data_t data;
+ *            if (sensor_init(&hadc1, &htim3) == EV_STATUS_OK) {
+ *                sensor_read_all(&data);
+ *                // data.batt_temp_c, data.throttle_pct etc. are now valid
+ *            }
+ *          @endcode
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2025
+ */
+
+#ifndef SENSOR_HAL_H
+#define SENSOR_HAL_H
+
+/* ─── Includes ────────────────────────────────────────────────────────────── */
+#include <stdint.h>
+#include <stdbool.h>
+#include "ev_types.h"
+#include "ev_config.h"
+#include "stm32f1xx_hal.h"
+
+/* ─── Public Function Declarations ───────────────────────────────────────── */
+
+/**
+ * @brief  Initialise the sensor HAL module.
+ *
+ * @details Must be called once before any sensor read function.
+ *          Stores the ADC and Timer handles for use in all subsequent reads.
+ *          Does NOT start any conversion — reads are on-demand (polling).
+ *
+ * @param  hadc   Pointer to the initialised ADC handle (ADC1).
+ *                Must not be NULL.
+ * @param  htim   Pointer to the initialised Timer handle (TIM3, encoder mode).
+ *                Must not be NULL.
+ *
+ * @retval EV_STATUS_OK       Initialisation successful.
+ * @retval EV_STATUS_INVALID  One or both handle pointers are NULL.
+ */
+ev_status_t sensor_init(ADC_HandleTypeDef *hadc, TIM_HandleTypeDef *htim);
+
+/**
+ * @brief  Read all sensors and populate a sensor_data_t structure.
+ *
+ * @details This is the primary function called by the main loop each cycle.
+ *          It reads every sensor in sequence and fills all fields of the
+ *          provided sensor_data_t struct.
+ *
+ *          If any individual sensor read fails, the corresponding field is
+ *          set to a safe default (0 or false) and the function returns
+ *          EV_STATUS_ERROR so the caller can act on the partial data.
+ *
+ * @param  data  Pointer to sensor_data_t struct to populate. Must not be NULL.
+ *
+ * @retval EV_STATUS_OK       All sensors read successfully.
+ * @retval EV_STATUS_INVALID  data pointer is NULL.
+ * @retval EV_STATUS_ERROR    One or more sensor reads returned an error.
+ * @retval EV_STATUS_NOT_READY sensor_init() has not been called yet.
+ */
+ev_status_t sensor_read_all(sensor_data_t *data);
+
+/**
+ * @brief  Read battery temperature from ADC channel 0 (PA0).
+ *
+ * @details Performs a single ADC conversion and converts the 12-bit raw value
+ *          to degrees Celsius using the LM35 transfer function:
+ *          temperature_C = (adc_voltage_V / EV_TEMP_SENSOR_MV_PER_DEG) * 1000
+ *
+ * @retval Battery temperature in degrees Celsius.
+ *         Returns 0.0f if the ADC read fails (safe default: no false fault).
+ */
+float sensor_read_batt_temp(void);
+
+/**
+ * @brief  Read motor temperature from ADC channel 1 (PA1).
+ *
+ * @details Same LM35 conversion as battery temperature, different channel.
+ *
+ * @retval Motor temperature in degrees Celsius. Returns 0.0f on error.
+ */
+float sensor_read_motor_temp(void);
+
+/**
+ * @brief  Read battery current from ADC channel 2 (PA2).
+ *
+ * @details Uses the ACS712-20A Hall-effect current sensor transfer function:
+ *          - Sensor output: 2.5V at 0A
+ *          - Sensitivity: 100mV per Ampere
+ *          - Positive value: battery discharging (powering the motor)
+ *          - Negative value: battery charging (regenerative braking)
+ *
+ * @retval Battery current in Amperes (signed). Returns 0.0f on error.
+ */
+float sensor_read_current(void);
+
+/**
+ * @brief  Read battery pack voltage from ADC channel 3 (PA3).
+ *
+ * @details A resistor voltage divider scales the 48V battery pack voltage
+ *          down to fit in the 0–3.3V ADC input range.
+ *          Divider: R1=100kΩ, R2=10kΩ → ratio = (R1+R2)/R2 = 11
+ *          battery_V = adc_voltage_V * 11.0
+ *
+ * @retval Battery pack voltage in Volts. Returns 0.0f on error.
+ */
+float sensor_read_voltage(void);
+
+/**
+ * @brief  Read motor speed from TIM3 encoder input (PA6/PA7).
+ *
+ * @details TIM3 is configured in encoder mode. The counter increments/
+ *          decrements with each encoder pulse. This function reads the
+ *          counter and converts it to RPM using the PPR constant.
+ *
+ * @retval Motor speed in RPM. Returns 0 if timer handle not initialised.
+ */
+uint16_t sensor_read_speed(void);
+
+/**
+ * @brief  Read throttle position from ADC channel 4 (PA4).
+ *
+ * @details A 10kΩ potentiometer provides 0–3.3V. This is linearly mapped
+ *          to a 0–100% throttle percentage.
+ *          Values are clamped to 100 maximum to prevent invalid motor commands.
+ *
+ * @retval Throttle position as a percentage (0 = released, 100 = full).
+ *         Returns 0 on error.
+ */
+uint8_t sensor_read_throttle(void);
+
+/**
+ * @brief  Read brake switch state from GPIO PB0.
+ *
+ * @details The brake switch is wired active-low with an internal pull-up:
+ *          - Switch open (not pressed):  PB0 = HIGH → returns false
+ *          - Switch closed (pressed):    PB0 = LOW  → returns true
+ *
+ *          A 20ms software debounce is applied to prevent false triggers
+ *          from switch bounce on rapid presses.
+ *
+ * @retval true  = brake is pressed.
+ * @retval false = brake is released.
+ */
+bool sensor_read_brake(void);
+
+/**
+ * @brief  Read manual fault trigger switch from GPIO PB1.
+ *
+ * @details Same active-low logic as the brake switch.
+ *          Used during testing to manually inject a fault and verify
+ *          the fault manager and state machine respond correctly.
+ *
+ * @retval true  = fault switch is pressed (inject fault).
+ * @retval false = fault switch is released.
+ */
+bool sensor_read_fault_switch(void);
+
+/* ─── Sprint 5 — I2C Temperature Sensor Functions ────────────────────────── */
+
+/**
+ * @brief  Enable I2C-based battery temperature sensing (TMP102).
+ *
+ * @details STUB in Sprint 2–4. Implemented in Sprint 5.
+ *          Calling with NULL keeps ADC simulation active.
+ *          Calling with a valid hi2c1 handle switches sensor_read_batt_temp()
+ *          to read from the TMP102 over I2C instead of the ADC potentiometer.
+ *
+ * @param  hi2c  Pointer to I2C1 handle. NULL = keep ADC simulation.
+ *
+ * @retval EV_STATUS_OK        I2C handle stored (or NULL accepted as stub).
+ * @retval EV_STATUS_INVALID   hi2c non-NULL but TMP102 does not respond.
+ * @retval EV_STATUS_NOT_READY sensor_init() has not been called first.
+ */
+ev_status_t sensor_enable_i2c_temp(I2C_HandleTypeDef *hi2c);
+
+/**
+ * @brief  Return which backend is in use for battery temperature reading.
+ *
+ * @retval EV_PROTO_STATUS_STUB   Using ADC simulation (Sprint 1–4 default).
+ * @retval EV_PROTO_STATUS_ACTIVE Using real TMP102 over I2C (Sprint 5+).
+ */
+ev_proto_status_t sensor_get_temp_backend(void);
+
+#endif /* SENSOR_HAL_H */

--- a/core/src/sensor_hal.c
+++ b/core/src/sensor_hal.c
@@ -1,0 +1,570 @@
+/**
+ * @file    sensor_hal.c
+ * @brief   Sensor HAL implementation — reads all EV ECU sensors
+ *
+ * @details This file implements the functions declared in sensor_hal.h.
+ *          It reads 5 ADC channels, 1 encoder timer, and 2 GPIO pins.
+ *
+ *          All hardware access goes through the STM32 HAL functions.
+ *          This makes it easy to:
+ *            1. Test with mocks (unit tests run on a PC)
+ *            2. Port to a different STM32 (only change the init, not the logic)
+ *
+ *          Sensor wiring (from ev_config.h and hardware design doc):
+ *            PA0 → ADC1 CH0 → Battery temperature (LM35)
+ *            PA1 → ADC1 CH1 → Motor temperature (LM35)
+ *            PA2 → ADC1 CH2 → Battery current (ACS712-20A)
+ *            PA3 → ADC1 CH3 → Battery voltage (resistor divider)
+ *            PA4 → ADC1 CH4 → Throttle potentiometer
+ *            PA6 → TIM3 CH1 → Encoder channel A
+ *            PA7 → TIM3 CH2 → Encoder channel B
+ *            PB0 → GPIO IN  → Brake switch (active low)
+ *            PB1 → GPIO IN  → Fault trigger switch (active low)
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2025
+ */
+
+/* ─── Includes ────────────────────────────────────────────────────────────── */
+#include "sensor_hal.h"
+#include "ev_config.h"
+
+/* ─── Private Variables ──────────────────────────────────────────────────── */
+
+/* HAL handles stored at initialisation, used by all read functions */
+/* 'static' means these are only visible inside this file (good practice) */
+static ADC_HandleTypeDef *s_hadc1 = NULL;
+static TIM_HandleTypeDef *s_htim3 = NULL;
+
+/* Flag to track whether sensor_init() has been called successfully */
+static bool s_initialised = false;
+
+/* I2C handle for TMP102 temperature sensor (Sprint 5) — NULL = ADC simulation */
+static I2C_HandleTypeDef *s_hi2c1           = NULL;
+static ev_proto_status_t  s_temp_backend    = EV_PROTO_STATUS_STUB;
+
+/* Previous brake and fault switch states for debounce */
+static GPIO_PinState s_brake_prev_state      = GPIO_PIN_SET;   /* HIGH = released */
+static GPIO_PinState s_fault_sw_prev_state   = GPIO_PIN_SET;
+static uint32_t      s_brake_debounce_tick   = 0U;
+static uint32_t      s_fault_sw_debounce_tick = 0U;
+static bool          s_brake_stable          = false;
+static bool          s_fault_sw_stable       = false;
+
+/* ─── Private Function Declarations ─────────────────────────────────────── */
+static uint32_t  priv_adc_read_channel(uint32_t channel);
+static float     priv_adc_to_voltage(uint32_t raw_adc);
+static bool      priv_read_gpio_debounced(GPIO_TypeDef   *port,
+                                           uint16_t        pin,
+                                           GPIO_PinState  *prev_state,
+                                           uint32_t       *debounce_tick,
+                                           bool           *stable_state);
+
+/* ─── Public Function Implementations ───────────────────────────────────── */
+
+/**
+ * @brief Initialise the sensor HAL module.
+ */
+ev_status_t sensor_init(ADC_HandleTypeDef *hadc, TIM_HandleTypeDef *htim)
+{
+    /*
+     * Validate input pointers.
+     * If either handle is NULL, we cannot read sensors.
+     * This catches mistakes like calling sensor_init(NULL, &htim3).
+     */
+    if (hadc == NULL || htim == NULL)
+    {
+        return EV_STATUS_INVALID;
+    }
+
+    s_brake_prev_state      = GPIO_PIN_SET;   /* Reset to HIGH (released) */
+    s_fault_sw_prev_state   = GPIO_PIN_SET;
+    s_brake_debounce_tick   = 0U;
+    s_fault_sw_debounce_tick = 0U;
+    s_brake_stable          = false;
+    s_fault_sw_stable       = false;
+
+    /* Store handles for use by all read functions */
+    s_hadc1 = hadc;
+    s_htim3 = htim;
+
+    /* Start encoder interface — TIM3 will count encoder pulses from now on */
+    if (HAL_TIM_Encoder_Start(s_htim3, TIM_CHANNEL_1) != HAL_OK)
+    {
+        /* Encoder start failed — return error but don't block other sensors */
+        return EV_STATUS_HAL_ERROR;
+    }
+
+    /* Mark module as ready */
+    s_initialised = true;
+
+    return EV_STATUS_OK;
+}
+
+/**
+ * @brief Read all sensors and populate a sensor_data_t structure.
+ */
+ev_status_t sensor_read_all(sensor_data_t *data)
+{
+    /* Guard: caller must pass a valid pointer */
+    if (data == NULL)
+    {
+        return EV_STATUS_INVALID;
+    }
+
+    /* Guard: sensor_init() must have been called first */
+    if (s_initialised == false)
+    {
+        return EV_STATUS_NOT_READY;
+    }
+
+    /*
+     * Read each sensor into the struct.
+     * We read all fields even if one fails, so the caller always gets
+     * the most complete picture possible.
+     *
+     * NOTE: We use a local 'status' variable to track if anything failed.
+     * A single failed read still populates the rest of the struct.
+     */
+    ev_status_t status = EV_STATUS_OK;
+
+    data->batt_temp_c  = sensor_read_batt_temp();
+    data->motor_temp_c = sensor_read_motor_temp();
+    data->current_a    = sensor_read_current();
+    data->voltage_v    = sensor_read_voltage();
+    data->speed_rpm    = sensor_read_speed();
+    data->throttle_pct = sensor_read_throttle();
+    data->brake_active = sensor_read_brake();
+    data->fault_switch = sensor_read_fault_switch();
+
+    /*
+     * Basic sanity check: if all ADC values came back as exactly 0.0,
+     * it is likely the ADC handle was not properly configured.
+     * This is a heuristic — real hardware should never have all zeros simultaneously.
+     */
+    if ((data->batt_temp_c == 0.0f) &&
+        (data->motor_temp_c == 0.0f) &&
+        (data->voltage_v == 0.0f))
+    {
+        /* Possibly an ADC issue — caller should be aware */
+        status = EV_STATUS_ERROR;
+    }
+
+    return status;
+}
+
+/**
+ * @brief Read battery temperature from ADC channel 0.
+ */
+float sensor_read_batt_temp(void)
+{
+    uint32_t raw_adc;
+    float    voltage_v;
+    float    temperature_c;
+
+    /* Read the raw ADC value (0–4095 for 12-bit ADC) */
+    raw_adc = priv_adc_read_channel(ADC_CHANNEL_0);
+
+    /* Convert ADC count to voltage in Volts */
+    voltage_v = priv_adc_to_voltage(raw_adc);
+
+    /*
+     * LM35 temperature sensor transfer function:
+     *   Output: 10mV per degree Celsius
+     *   So: temperature = voltage / 10mV_per_degree
+     *   Example: 350mV → 35.0°C
+     *
+     * EV_TEMP_SENSOR_MV_PER_DEG = 10.0f (from ev_config.h)
+     * We convert voltage from V to mV by multiplying by 1000.
+     */
+    temperature_c = (voltage_v * 1000.0f) / EV_TEMP_SENSOR_MV_PER_DEG;
+
+    return temperature_c;
+}
+
+/**
+ * @brief Read motor temperature from ADC channel 1.
+ */
+float sensor_read_motor_temp(void)
+{
+    uint32_t raw_adc;
+    float    voltage_v;
+    float    temperature_c;
+
+    raw_adc = priv_adc_read_channel(ADC_CHANNEL_1);
+    voltage_v = priv_adc_to_voltage(raw_adc);
+
+    /* Same LM35 transfer function as battery temperature */
+    temperature_c = (voltage_v * 1000.0f) / EV_TEMP_SENSOR_MV_PER_DEG;
+
+    return temperature_c;
+}
+
+/**
+ * @brief Read battery current from ADC channel 2.
+ */
+float sensor_read_current(void)
+{
+    uint32_t raw_adc;
+    float    voltage_v;
+    float    current_a;
+
+    raw_adc = priv_adc_read_channel(ADC_CHANNEL_2);
+    voltage_v = priv_adc_to_voltage(raw_adc);
+
+    /*
+     * ACS712-20A current sensor transfer function:
+     *   At 0 Amps: output = 2.5V (EV_CURRENT_SENSOR_MIDPOINT_MV / 1000)
+     *   Sensitivity: 100mV per Amp (EV_CURRENT_SENSOR_MV_PER_AMP)
+     *
+     *   current = (voltage - 2.5) / 0.1
+     *
+     * Positive: motor is drawing current (discharging battery)
+     * Negative: regen braking is charging the battery
+     */
+    float midpoint_v = (float)EV_CURRENT_SENSOR_MIDPOINT_MV / 1000.0f;
+    float sensitivity_v_per_a = EV_CURRENT_SENSOR_MV_PER_AMP / 1000.0f;
+
+    current_a = (voltage_v - midpoint_v) / sensitivity_v_per_a;
+
+    return current_a;
+}
+
+/**
+ * @brief Read battery pack voltage from ADC channel 3.
+ */
+float sensor_read_voltage(void)
+{
+    uint32_t raw_adc;
+    float    adc_voltage_v;
+    float    battery_voltage_v;
+
+    raw_adc = priv_adc_read_channel(ADC_CHANNEL_3);
+    adc_voltage_v = priv_adc_to_voltage(raw_adc);
+
+    /*
+     * Resistor voltage divider reversal:
+     *   The divider scaled the battery voltage DOWN by a factor of
+     *   EV_VOLTAGE_DIVIDER_RATIO (R2/(R1+R2) = 10/(100+10) ≈ 0.0909)
+     *
+     *   To get the real battery voltage, we divide the measured ADC voltage
+     *   by the divider ratio:
+     *   battery_V = adc_voltage_V / EV_VOLTAGE_DIVIDER_RATIO
+     *             = adc_voltage_V / 0.0909
+     *             = adc_voltage_V * 11.0
+     */
+    battery_voltage_v = adc_voltage_v / EV_VOLTAGE_DIVIDER_RATIO;
+
+    return battery_voltage_v;
+}
+
+/**
+ * @brief Read motor speed from TIM3 encoder.
+ */
+uint16_t sensor_read_speed(void)
+{
+    uint32_t encoder_count;
+    uint16_t speed_rpm;
+
+    /* Guard: timer must be initialised */
+    if (s_htim3 == NULL)
+    {
+        return 0U;
+    }
+
+    /*
+     * Read the current encoder counter value.
+     * TIM3 in encoder mode counts up/down with each encoder pulse.
+     * We read it, calculate RPM, then reset the counter.
+     *
+     * RPM calculation:
+     *   counts_per_rev = EV_ENCODER_PPR (from ev_config.h)
+     *   period = EV_SENSOR_SPEED_PERIOD_MS / 1000.0 seconds
+     *   revolutions = encoder_count / counts_per_rev
+     *   RPM = revolutions / period * 60
+     *       = (encoder_count / PPR) * (1000 / period_ms) * 60
+     */
+    encoder_count = (uint32_t)__HAL_TIM_GET_COUNTER(s_htim3);
+
+    /* Reset counter for next measurement period */
+    s_htim3->Instance->CNT = 0U;
+
+    /*
+     * Convert count to RPM.
+     * Cast to float for division, then back to uint16_t.
+     * Limit to uint16_t max to prevent overflow.
+     */
+    float rpm_f = ((float)encoder_count / (float)EV_ENCODER_PPR)
+                  * (1000.0f / (float)EV_SENSOR_SPEED_PERIOD_MS)
+                  * 60.0f;
+
+    /* Clamp to uint16_t range */
+    if (rpm_f > 65535.0f)
+    {
+        speed_rpm = 65535U;
+    }
+    else
+    {
+        speed_rpm = (uint16_t)rpm_f;
+    }
+
+    return speed_rpm;
+}
+
+/**
+ * @brief Read throttle position from ADC channel 4.
+ */
+uint8_t sensor_read_throttle(void)
+{
+    uint32_t raw_adc;
+    uint8_t  throttle_pct;
+
+    raw_adc = priv_adc_read_channel(ADC_CHANNEL_4);
+
+    /*
+     * Linear mapping: 0 → 0%, 4095 → 100%
+     * Formula: pct = (raw / 4095) * 100
+     *
+     * Integer arithmetic version to avoid float:
+     * pct = (raw * 100U) / EV_ADC_MAX_VALUE
+     */
+    throttle_pct = (uint8_t)((raw_adc * 100U) / EV_ADC_MAX_VALUE);
+
+    /* Safety clamp: never return more than 100 */
+    if (throttle_pct > EV_MOTOR_MAX_DUTY_PCT)
+    {
+        throttle_pct = EV_MOTOR_MAX_DUTY_PCT;
+    }
+
+    return throttle_pct;
+}
+
+/**
+ * @brief Read brake switch state from GPIO PB0.
+ */
+bool sensor_read_brake(void)
+{
+    return priv_read_gpio_debounced(GPIOB,
+                                    GPIO_PIN_0,
+                                    &s_brake_prev_state,
+                                    &s_brake_debounce_tick,
+                                    &s_brake_stable);
+}
+
+/**
+ * @brief Read manual fault trigger switch from GPIO PB1.
+ */
+bool sensor_read_fault_switch(void)
+{
+    return priv_read_gpio_debounced(GPIOB,
+                                    GPIO_PIN_1,
+                                    &s_fault_sw_prev_state,
+                                    &s_fault_sw_debounce_tick,
+                                    &s_fault_sw_stable);
+}
+
+/* ─── Private Function Implementations ──────────────────────────────────── */
+
+/**
+ * @brief  Read one ADC channel by selecting it then triggering a conversion.
+ *
+ * @details This function selects the requested channel, starts one conversion
+ *          in polling mode, waits for it to complete, and returns the value.
+ *
+ *          We use polling (not DMA/interrupt) for Sprint 2 because it is
+ *          simple and easy to understand. DMA will be considered in Sprint 5.
+ *
+ * @param  channel  ADC channel number (ADC_CHANNEL_0 through ADC_CHANNEL_4)
+ * @retval 12-bit ADC result (0–4095), or 0U on HAL error
+ */
+static uint32_t priv_adc_read_channel(uint32_t channel)
+{
+    ADC_ChannelConfTypeDef channel_config;
+    uint32_t               adc_value = 0U;
+
+    /* Guard: ADC must be initialised */
+    if (s_hadc1 == NULL)
+    {
+        return 0U;
+    }
+
+    /*
+     * Configure the channel we want to sample.
+     * We must do this before each conversion because we share one ADC
+     * across all 5 channels (single-channel sequential reads).
+     */
+    channel_config.Channel      = channel;
+    channel_config.Rank         = ADC_RANK_1;
+    channel_config.SamplingTime = ADC_SAMPLETIME_239CYCLES_5;
+
+    if (HAL_ADC_ConfigChannel(s_hadc1, &channel_config) != HAL_OK)
+    {
+        /* Channel configuration failed — return 0 (safe default) */
+        return 0U;
+    }
+
+    /* Start a single conversion */
+    if (HAL_ADC_Start(s_hadc1) != HAL_OK)
+    {
+        return 0U;
+    }
+
+    /*
+     * Wait for conversion to complete.
+     * HAL_MAX_DELAY means "wait forever" — in practice the ADC is fast.
+     * Sprint 5: replace with a timeout value and handle timeout gracefully.
+     */
+    if (HAL_ADC_PollForConversion(s_hadc1, HAL_MAX_DELAY) != HAL_OK)
+    {
+        return 0U;
+    }
+
+    /* Read the 12-bit conversion result */
+    adc_value = HAL_ADC_GetValue(s_hadc1);
+
+    /* Stop the ADC to prepare for the next channel selection */
+    (void)HAL_ADC_Stop(s_hadc1);
+
+    return adc_value;
+}
+
+/**
+ * @brief  Convert a raw 12-bit ADC value to a voltage in Volts.
+ *
+ * @details Uses the ADC reference voltage and resolution from ev_config.h.
+ *          formula: voltage_V = (raw / ADC_MAX_VALUE) * (VREF_mV / 1000.0)
+ *
+ * @param  raw_adc  12-bit ADC result (0–4095)
+ * @retval Voltage in Volts (0.0 to 3.3V)
+ */
+static float priv_adc_to_voltage(uint32_t raw_adc)
+{
+    float voltage_v;
+
+    /*
+     * EV_ADC_MAX_VALUE = 4095 (12-bit)
+     * EV_ADC_VREF_MV   = 3300 (3.3V reference)
+     */
+    voltage_v = ((float)raw_adc / (float)EV_ADC_MAX_VALUE)
+                * ((float)EV_ADC_VREF_MV / 1000.0f);
+
+    return voltage_v;
+}
+
+/**
+ * @brief  Read a GPIO pin with software debounce.
+ *
+ * @details Switch contacts physically "bounce" when pressed, creating rapid
+ *          HIGH/LOW transitions before settling. Without debounce, one press
+ *          can look like 10–20 presses to the firmware.
+ *
+ *          Debounce algorithm:
+ *            1. Read the current GPIO state
+ *            2. If it changed from the previous state, record the time
+ *            3. Only update the stable output if the state has held stable
+ *               for EV_GPIO_DEBOUNCE_MS milliseconds
+ *
+ * @param  port          GPIO port (GPIOB)
+ * @param  pin           GPIO pin number
+ * @param  prev_state    Pointer to previous raw state (persists between calls)
+ * @param  debounce_tick Pointer to debounce timestamp (persists between calls)
+ * @param  stable_state  Pointer to debounced output state (persists between calls)
+ *
+ * @retval Debounced switch state:
+ *         true  = switch pressed (GPIO LOW, active-low wiring)
+ *         false = switch released (GPIO HIGH)
+ */
+static bool priv_read_gpio_debounced(GPIO_TypeDef  *port,
+                                      uint16_t       pin,
+                                      GPIO_PinState *prev_state,
+                                      uint32_t      *debounce_tick,
+                                      bool          *stable_state)
+{
+    GPIO_PinState current_state = HAL_GPIO_ReadPin(port, pin);
+
+    if (current_state != *prev_state)
+    {
+        /*
+         * State has changed — start (or restart) the debounce timer.
+         * We record when the change happened.
+         */
+        *prev_state    = current_state;
+        *debounce_tick = HAL_GetTick();
+    }
+    else
+    {
+        /*
+         * State is the same as last read.
+         * Check if it has been stable for long enough.
+         */
+        uint32_t elapsed_ms = HAL_GetTick() - *debounce_tick;
+
+        if (elapsed_ms >= EV_GPIO_DEBOUNCE_MS)
+        {
+            /*
+             * State has been stable for EV_GPIO_DEBOUNCE_MS.
+             * Accept it as the true switch state.
+             *
+             * Active-low conversion:
+             *   GPIO_PIN_RESET (LOW)  → switch pressed  → return true
+             *   GPIO_PIN_SET   (HIGH) → switch released → return false
+             */
+            *stable_state = (current_state == GPIO_PIN_RESET);
+        }
+    }
+
+    return *stable_state;
+}
+
+/* ─── Sprint 5 Stub Implementations ─────────────────────────────────────── */
+
+/**
+ * @brief Enable I2C battery temperature sensing — STUB (Sprint 2–4).
+ *
+ * @details Sprint 5 TODO: Replace stub body with:
+ *   1. Validate hi2c is not NULL
+ *   2. Call HAL_I2C_IsDeviceReady(hi2c, EV_I2C_TMP102_ADDR_8BIT, 3, 10)
+ *   3. If device responds: store handle, set s_temp_backend = ACTIVE
+ *   4. If no response: return EV_STATUS_INVALID (keep ADC fallback)
+ */
+ev_status_t sensor_enable_i2c_temp(I2C_HandleTypeDef *hi2c)
+{
+    /*
+     * Sprint 2–4 stub: Accept any handle (including NULL).
+     * NULL = stay in ADC simulation mode.
+     * Non-NULL stored but not used until Sprint 5 implementation.
+     */
+    s_hi2c1 = hi2c;
+
+    if (hi2c == NULL)
+    {
+        /* NULL explicitly passed — caller wants ADC simulation */
+        s_temp_backend = EV_PROTO_STATUS_STUB;
+    }
+    else
+    {
+        /*
+         * Non-NULL handle stored. Sprint 5 will verify the device here.
+         * For now, mark as stub — actual I2C reads not implemented yet.
+         *
+         * Sprint 5 TODO: ping device and set EV_PROTO_STATUS_ACTIVE.
+         */
+        s_temp_backend = EV_PROTO_STATUS_STUB;
+    }
+
+    if (s_initialised == false)
+    {
+        return EV_STATUS_NOT_READY;
+    }
+
+    return EV_STATUS_OK;
+}
+
+/**
+ * @brief Return current temperature sensor backend — STUB (Sprint 2–4).
+ */
+ev_proto_status_t sensor_get_temp_backend(void)
+{
+    return s_temp_backend;
+}

--- a/tests/mocks/mock_stm32_hal_adc.c
+++ b/tests/mocks/mock_stm32_hal_adc.c
@@ -1,0 +1,122 @@
+/**
+ * @file    mock_stm32_hal_adc.c
+ * @brief   Mock STM32 ADC HAL implementation for unit testing
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2025
+ */
+
+#include "mock_stm32_hal_adc.h"
+#include <stdbool.h>
+#include <string.h>
+
+/* ─── Mock state ─────────────────────────────────────────────────────────── */
+
+/* Stores the fake ADC values for each channel */
+static uint32_t s_mock_adc_values[MOCK_ADC_MAX_CHANNELS];
+
+/* Stores which channel was most recently configured (to return right value) */
+static uint32_t s_current_channel = 0U;
+
+/* Error injection flags */
+static bool s_force_start_error    = false;
+static bool s_force_poll_timeout   = false;
+
+/* ─── Mock control functions ─────────────────────────────────────────────── */
+
+void mock_adc_reset(void)
+{
+    (void)memset(s_mock_adc_values, 0, sizeof(s_mock_adc_values));
+    s_current_channel    = 0U;
+    s_force_start_error  = false;
+    s_force_poll_timeout = false;
+}
+
+void mock_adc_set_channel_value(uint32_t channel, uint32_t adc_value)
+{
+    if (channel < MOCK_ADC_MAX_CHANNELS)
+    {
+        s_mock_adc_values[channel] = adc_value;
+    }
+}
+
+void mock_adc_set_start_error(bool force_error)
+{
+    s_force_start_error = force_error;
+}
+
+void mock_adc_set_poll_timeout(bool force_timeout)
+{
+    s_force_poll_timeout = force_timeout;
+}
+
+/* ─── Mock HAL function implementations ─────────────────────────────────── */
+/* These replace the real STM32 HAL functions during unit tests.            */
+
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc) {
+    (void)hadc; return HAL_OK;
+}
+
+void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
+    (void)hadc;
+}
+
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef      *hadc,
+                                         ADC_ChannelConfTypeDef *sConfig)
+{
+    (void)hadc;  /* Unused in mock — suppress warning */
+
+    /* Remember which channel was configured so GetValue() returns the right one */
+    if (sConfig != NULL)
+    {
+        s_current_channel = sConfig->Channel;
+    }
+
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef *hadc)
+{
+    (void)hadc;  /* Unused in mock */
+
+    if (s_force_start_error == true)
+    {
+        return HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc,
+                                             uint32_t           Timeout)
+{
+    (void)hadc;
+    (void)Timeout;
+
+    if (s_force_poll_timeout == true)
+    {
+        return HAL_TIMEOUT;
+    }
+
+    return HAL_OK;
+}
+
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef *hadc)
+{
+    (void)hadc;
+
+    /* Return the value that was set for the most recently configured channel */
+    if (s_current_channel < MOCK_ADC_MAX_CHANNELS)
+    {
+        return s_mock_adc_values[s_current_channel];
+    }
+
+    return 0U;
+}
+
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef *hadc)
+{
+    (void)hadc;
+    return HAL_OK;
+}

--- a/tests/mocks/mock_stm32_hal_adc.h
+++ b/tests/mocks/mock_stm32_hal_adc.h
@@ -1,0 +1,64 @@
+/**
+ * @file    mock_stm32_hal_adc.h
+ * @brief   Mock (fake) STM32 ADC HAL for unit testing
+ *
+ * @details This mock replaces the real STM32 HAL ADC functions during
+ *          unit tests. Instead of reading real hardware registers, it
+ *          returns values that we set programmatically in test code.
+ *
+ *          How to use in a test:
+ *          @code
+ *            // Set what the ADC will "read" for battery temp channel
+ *            mock_adc_set_channel_value(ADC_CHANNEL_0, 2048U);
+ *
+ *            // Now call the real function under test
+ *            float temp = sensor_read_batt_temp();
+ *
+ *            // Check it calculated correctly
+ *            TEST_ASSERT_FLOAT_WITHIN(1.0f, 50.0f, temp);
+ *          @endcode
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2025
+ */
+
+#ifndef MOCK_STM32_HAL_ADC_H
+#define MOCK_STM32_HAL_ADC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32f1xx_hal_adc.h"
+
+/* Maximum number of ADC channels the mock supports */
+#define MOCK_ADC_MAX_CHANNELS  (18U)
+
+/* ─── Mock control functions (called by test code) ───────────────────────── */
+
+/**
+ * @brief  Reset all mock ADC values to zero.
+ *         Call this in your test setUp() function.
+ */
+void mock_adc_reset(void);
+
+/**
+ * @brief  Set the value that the mock ADC will return for a given channel.
+ *
+ * @param  channel    ADC channel number (ADC_CHANNEL_0 through ADC_CHANNEL_4)
+ * @param  adc_value  12-bit ADC value to return (0–4095)
+ */
+void mock_adc_set_channel_value(uint32_t channel, uint32_t adc_value);
+
+/**
+ * @brief  Force HAL_ADC_Start() to return HAL_ERROR (test error handling).
+ * @param  force_error  true = return HAL_ERROR, false = return HAL_OK
+ */
+void mock_adc_set_start_error(bool force_error);
+
+/**
+ * @brief  Force HAL_ADC_PollForConversion() to return HAL_TIMEOUT.
+ * @param  force_timeout  true = return HAL_TIMEOUT, false = return HAL_OK
+ */
+void mock_adc_set_poll_timeout(bool force_timeout);
+
+#endif /* MOCK_STM32_HAL_ADC_H */

--- a/tests/mocks/mock_stm32_hal_gpio.c
+++ b/tests/mocks/mock_stm32_hal_gpio.c
@@ -1,0 +1,138 @@
+/**
+ * @file    mock_stm32_hal_gpio.c
+ * @brief   Mock STM32 GPIO HAL implementation
+ * @author  BaseSync Team
+ */
+
+#include "mock_stm32_hal_gpio.h"
+#include <string.h>
+
+/* Simple lookup: store pin states for GPIOA, GPIOB, GPIOC (3 ports, 16 pins each) */
+#define MOCK_NUM_PORTS  (3U)
+#define MOCK_NUM_PINS   (16U)
+
+/* Map port pointers to indices */
+static GPIO_TypeDef * const s_port_map[MOCK_NUM_PORTS] = { GPIOA, GPIOB, GPIOC };
+static GPIO_PinState s_read_states[MOCK_NUM_PORTS][MOCK_NUM_PINS];
+static GPIO_PinState s_write_states[MOCK_NUM_PORTS][MOCK_NUM_PINS];
+
+/* ─── Private helper ─────────────────────────────────────────────────────── */
+static int priv_port_index(GPIO_TypeDef *GPIOx)
+{
+    int i;
+    for (i = 0; i < (int)MOCK_NUM_PORTS; i++)
+    {
+        if (s_port_map[i] == GPIOx) { return i; }
+    }
+    return -1;
+}
+
+static int priv_pin_index(uint16_t GPIO_Pin)
+{
+    int i;
+    for (i = 0; i < (int)MOCK_NUM_PINS; i++)
+    {
+        if (GPIO_Pin == (uint16_t)(1U << (uint16_t)i)) { return i; }
+    }
+    return -1;
+}
+
+/* ─── Mock control functions ─────────────────────────────────────────────── */
+
+void mock_gpio_reset(void)
+{
+    uint32_t p, n;
+    for (p = 0U; p < MOCK_NUM_PORTS; p++)
+    {
+        for (n = 0U; n < MOCK_NUM_PINS; n++)
+        {
+            s_read_states[p][n]  = GPIO_PIN_SET;   /* Default: HIGH = released */
+            s_write_states[p][n] = GPIO_PIN_RESET;
+        }
+    }
+}
+
+void mock_gpio_set_pin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState state)
+{
+    int port_idx = priv_port_index(GPIOx);
+    int pin_idx  = priv_pin_index(GPIO_Pin);
+
+    if ((port_idx >= 0) && (pin_idx >= 0))
+    {
+        s_read_states[port_idx][pin_idx] = state;
+    }
+}
+
+GPIO_PinState mock_gpio_get_written_pin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    int port_idx = priv_port_index(GPIOx);
+    int pin_idx  = priv_pin_index(GPIO_Pin);
+
+    if ((port_idx >= 0) && (pin_idx >= 0))
+    {
+        return s_write_states[port_idx][pin_idx];
+    }
+    return GPIO_PIN_RESET;
+}
+
+/* ─── Mock HAL function implementations ─────────────────────────────────── */
+
+void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, void *GPIO_Init) {
+    (void)GPIOx; (void)GPIO_Init;
+}
+void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin) {
+    (void)GPIOx; (void)GPIO_Pin;
+}
+
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    int port_idx = priv_port_index(GPIOx);
+    int pin_idx  = priv_pin_index(GPIO_Pin);
+
+    if ((port_idx >= 0) && (pin_idx >= 0))
+    {
+        return s_read_states[port_idx][pin_idx];
+    }
+    return GPIO_PIN_SET;   /* Default HIGH if unknown */
+}
+
+void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+{
+    int port_idx = priv_port_index(GPIOx);
+    int pin_idx  = priv_pin_index(GPIO_Pin);
+
+    if ((port_idx >= 0) && (pin_idx >= 0))
+    {
+        s_write_states[port_idx][pin_idx] = PinState;
+    }
+}
+
+void HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
+{
+    int port_idx = priv_port_index(GPIOx);
+    int pin_idx  = priv_pin_index(GPIO_Pin);
+
+    if ((port_idx >= 0) && (pin_idx >= 0))
+    {
+        s_write_states[port_idx][pin_idx] =
+            (s_write_states[port_idx][pin_idx] == GPIO_PIN_SET)
+            ? GPIO_PIN_RESET : GPIO_PIN_SET;
+    }
+}
+
+/* ─── HAL_GetTick and HAL_Delay mocks (used for debounce) ────────────────── */
+
+static uint32_t s_mock_tick = 0U;
+
+/** Call this in tests to advance simulated time. */
+void mock_hal_set_tick(uint32_t tick_ms)
+{
+    s_mock_tick = tick_ms;
+}
+
+uint32_t HAL_GetTick(void)
+{
+    return s_mock_tick;
+}
+
+void HAL_Delay(uint32_t delay_ms) { (void)delay_ms; }

--- a/tests/mocks/mock_stm32_hal_gpio.h
+++ b/tests/mocks/mock_stm32_hal_gpio.h
@@ -1,0 +1,33 @@
+/**
+ * @file    mock_stm32_hal_gpio.h
+ * @brief   Mock STM32 GPIO HAL for unit testing
+ * @author  BaseSync Team
+ */
+
+#ifndef MOCK_STM32_HAL_GPIO_H
+#define MOCK_STM32_HAL_GPIO_H
+
+#include "stm32f1xx_hal_gpio.h"
+#include <stdbool.h>
+
+/* ─── Mock control functions ─────────────────────────────────────────────── */
+
+/** Reset all GPIO mock pin states to HIGH (released). */
+void mock_gpio_reset(void);
+
+/**
+ * @brief  Set what HAL_GPIO_ReadPin() returns for a specific port+pin.
+ * @param  GPIOx    GPIO port
+ * @param  GPIO_Pin Pin mask
+ * @param  state    GPIO_PIN_SET (HIGH) or GPIO_PIN_RESET (LOW)
+ */
+void mock_gpio_set_pin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState state);
+
+/**
+ * @brief  Get the last value written by HAL_GPIO_WritePin() for verification.
+ */
+GPIO_PinState mock_gpio_get_written_pin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+
+void mock_hal_set_tick(uint32_t tick_ms);
+
+#endif /* MOCK_STM32_HAL_GPIO_H */

--- a/tests/mocks/mock_stm32_hal_tim.c
+++ b/tests/mocks/mock_stm32_hal_tim.c
@@ -1,0 +1,114 @@
+/**
+ * @file    mock_stm32_hal_tim.c
+ * @brief   Mock STM32 Timer HAL implementation
+ * @author  BaseSync Team
+ */
+
+#include "mock_stm32_hal_tim.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+/* ─── Mock state ─────────────────────────────────────────────────────────── */
+static uint32_t s_encoder_count     = 0U;
+static uint32_t s_compare_value     = 0U;
+static uint32_t s_arr_value         = 3599U;  /* Default for 20kHz at 72MHz */
+static bool     s_pwm_start_error   = false;
+
+/* Shared TIM_TypeDef instance used by tests */
+static TIM_TypeDef s_mock_tim_instance = { .CCR1 = 0U, .ARR = 3599U, .CNT = 0U };
+
+/* ─── Mock control functions ─────────────────────────────────────────────── */
+
+void mock_tim_reset(void)
+{
+    s_encoder_count             = 0U;
+    s_compare_value             = 0U;
+    s_arr_value                 = 3599U;
+    s_pwm_start_error           = false;
+    s_mock_tim_instance.CCR1    = 0U;
+    s_mock_tim_instance.ARR     = 3599U;
+    s_mock_tim_instance.CNT     = 0U;
+}
+
+void mock_tim_set_encoder_count(uint32_t count)
+{
+    s_encoder_count           = count;
+    s_mock_tim_instance.CNT   = count;
+}
+
+uint32_t mock_tim_get_compare_value(void)
+{
+    return s_mock_tim_instance.CCR1;
+}
+
+uint32_t mock_tim_get_arr(void)
+{
+    return s_mock_tim_instance.ARR;
+}
+
+void mock_tim_set_arr(uint32_t arr)
+{
+    s_arr_value               = arr;
+    s_mock_tim_instance.ARR   = arr;
+}
+
+void mock_tim_set_pwm_start_error(bool force_error)
+{
+    s_pwm_start_error = force_error;
+}
+
+/**
+ * @brief Get the shared mock TIM instance pointer.
+ * Tests use this to set up a TIM_HandleTypeDef.
+ */
+TIM_TypeDef *mock_tim_get_instance(void)
+{
+    return &s_mock_tim_instance;
+}
+
+/* ─── Mock HAL function implementations ─────────────────────────────────── */
+
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim) {
+    (void)htim; return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim) {
+    (void)htim; return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+    (void)Channel;
+
+    if (s_pwm_start_error == true)
+    {
+        return HAL_ERROR;
+    }
+
+    /* Link the mock instance to the handle so macros work correctly */
+    if (htim != NULL)
+    {
+        htim->Instance = &s_mock_tim_instance;
+    }
+
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+    (void)htim;
+    (void)Channel;
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+    (void)Channel;
+
+    if (htim != NULL)
+    {
+        htim->Instance = &s_mock_tim_instance;
+    }
+
+    return HAL_OK;
+}

--- a/tests/mocks/mock_stm32_hal_tim.h
+++ b/tests/mocks/mock_stm32_hal_tim.h
@@ -1,0 +1,34 @@
+/**
+ * @file    mock_stm32_hal_tim.h
+ * @brief   Mock STM32 Timer HAL for unit testing
+ * @author  BaseSync Team
+ */
+
+#ifndef MOCK_STM32_HAL_TIM_H
+#define MOCK_STM32_HAL_TIM_H
+
+#include "stm32f1xx_hal_tim.h"
+#include <stdbool.h>
+
+/** Reset all timer mock state. */
+void mock_tim_reset(void);
+
+/** Set the encoder counter value (simulates motor rotating). */
+void mock_tim_set_encoder_count(uint32_t count);
+
+/** Get the last compare value written (used to verify PWM duty). */
+uint32_t mock_tim_get_compare_value(void);
+
+/** Get the ARR value set on the mock timer (used in duty calculations). */
+uint32_t mock_tim_get_arr(void);
+
+/** Set the ARR (period) of the mock timer. Default is 3599. */
+void mock_tim_set_arr(uint32_t arr);
+
+/** Force HAL_TIM_PWM_Start to return HAL_ERROR. */
+void mock_tim_set_pwm_start_error(bool force_error);
+
+/** @brief Get the shared mock TIM instance pointer. */
+TIM_TypeDef *mock_tim_get_instance(void);
+
+#endif /* MOCK_STM32_HAL_TIM_H */

--- a/tests/test_sensor_hal.c
+++ b/tests/test_sensor_hal.c
@@ -1,0 +1,383 @@
+/**
+ * @file    test_sensor_hal.c
+ * @brief   Unit tests for the sensor_hal module
+ *
+ * @details Tests every public function in sensor_hal.c:
+ *          - ADC channel reads (battery temp, motor temp, current, voltage, throttle)
+ *          - GPIO reads (brake switch, fault switch) with debounce
+ *          - sensor_read_all() integration
+ *
+ *          Each test follows the Arrange–Act–Assert (AAA) pattern:
+ *            Arrange: Set up mock ADC/GPIO values
+ *            Act:     Call the function under test
+ *            Assert:  Check the result with Unity assertions
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2025
+ */
+
+/* ─── Includes ────────────────────────────────────────────────────────────── */
+#include "Unity/unity.h"
+#include "sensor_hal.h"
+#include "ev_config.h"
+#include "mocks/mock_stm32_hal_adc.h"
+#include "mocks/mock_stm32_hal_gpio.h"
+#include "mocks/mock_stm32_hal_tim.h"
+
+/* ─── Test fixtures (HAL handles used by sensor_init) ───────────────────── */
+static ADC_HandleTypeDef s_test_hadc;
+static TIM_HandleTypeDef s_test_htim;
+
+/* ─── setUp and tearDown ─────────────────────────────────────────────────── */
+
+/**
+ * @brief Runs before EVERY test function.
+ * Resets all mocks and re-initialises sensor_hal.
+ */
+void sensor_setUp(void)
+{
+    /* Reset all mock state so tests do not affect each other */
+    mock_adc_reset();
+    mock_gpio_reset();
+    mock_tim_reset();
+
+    /* Reset simulated time to 0 */
+    mock_hal_set_tick(0U);
+
+    /* Set up the test HAL handles pointing at mock instances */
+    s_test_hadc.Instance = (uint32_t)0x40012400U;  /* ADC1 stub address */
+    s_test_htim.Instance = mock_tim_get_instance();
+
+    /* Re-initialise sensor_hal with fresh handles before each test */
+    (void)sensor_init(&s_test_hadc, &s_test_htim);
+}
+
+void sensor_tearDown(void)
+{
+    /* Nothing to clean up — mocks are reset in setUp */
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * BATTERY TEMPERATURE TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_batt_temp_adc_zero_returns_zero_degrees(void)
+{
+    /* Arrange: ADC returns 0 → 0V → 0°C */
+    mock_adc_set_channel_value(ADC_CHANNEL_0, 0U);
+
+    /* Act */
+    float result = sensor_read_batt_temp();
+
+    /* Assert: 0 ADC counts = 0V = 0°C */
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f, result);
+}
+
+void test_sensor_batt_temp_adc_midscale_returns_50_degrees(void)
+{
+    /*
+     * Arrange: ADC = 2048 → voltage ≈ 1.65V → temp = 1650mV / 10mV_per_deg = 165°C
+     *
+     * Wait — let's recalculate with the actual formula in sensor_hal.c:
+     * voltage = (2048 / 4095) * 3.3 = 1.6496V
+     * temp = (1.6496 * 1000) / 10.0 = 164.96 ≈ 165°C
+     *
+     * But our sensor range is 0–100°C, so midscale of the sensor range
+     * corresponds to a lower ADC value:
+     * For 50°C: voltage = 50 * 10mV = 500mV = 0.5V
+     * ADC for 0.5V = (0.5 / 3.3) * 4095 = 620.45 ≈ 620
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_0, 620U);
+
+    /* Act */
+    float result = sensor_read_batt_temp();
+
+    /* Assert: ADC=620 → ~50°C (±2°C tolerance for integer math rounding) */
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 50.0f, result);
+}
+
+void test_sensor_batt_temp_adc_fullscale_returns_max_voltage_temp(void)
+{
+    /* Arrange: ADC = 4095 → 3.3V → 330°C (LM35 at full ADC range) */
+    mock_adc_set_channel_value(ADC_CHANNEL_0, 4095U);
+
+    /* Act */
+    float result = sensor_read_batt_temp();
+
+    /* Assert: 3.3V / 10mV_per_deg = 330°C */
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 330.0f, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * MOTOR TEMPERATURE TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_motor_temp_adc_midscale_returns_same_as_batt_at_same_adc(void)
+{
+    /*
+     * Motor temp uses the same LM35 transfer function as battery temp.
+     * At the same ADC value, both should return the same temperature.
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_1, 620U);
+
+    float result = sensor_read_motor_temp();
+
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 50.0f, result);
+}
+
+void test_sensor_motor_temp_reads_different_channel_than_batt_temp(void)
+{
+    /*
+     * Set channel 0 (batt temp) to 0, channel 1 (motor temp) to 620.
+     * Motor temp must return ~50°C, proving it reads channel 1 not channel 0.
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_0, 0U);
+    mock_adc_set_channel_value(ADC_CHANNEL_1, 620U);
+
+    float batt_temp  = sensor_read_batt_temp();
+    float motor_temp = sensor_read_motor_temp();
+
+    /* Battery temp should be ~0, motor temp should be ~50 */
+    TEST_ASSERT_FLOAT_WITHIN(1.0f, 0.0f,  batt_temp);
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 50.0f, motor_temp);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * CURRENT SENSOR TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_current_adc_midscale_returns_zero_amps(void)
+{
+    /*
+     * ACS712 midpoint: 2.5V output = 0A.
+     * ADC for 2.5V = (2.5 / 3.3) * 4095 = 3102.27 ≈ 3102
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_2, 3102U);
+
+    float result = sensor_read_current();
+
+    /* Should be 0A ± 0.5A tolerance for ADC quantisation */
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f, result);
+}
+
+void test_sensor_current_above_midscale_returns_positive_current(void)
+{
+    /*
+     * ACS712: above 2.5V = positive current (discharge).
+     * At 3.0V: current = (3.0 - 2.5) / 0.1 = 5A
+     * ADC for 3.0V = (3.0 / 3.3) * 4095 = 3722
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_2, 3722U);
+
+    float result = sensor_read_current();
+
+    /* Should be ~+5A */
+    TEST_ASSERT_FLOAT_WITHIN(1.0f, 5.0f, result);
+}
+
+void test_sensor_current_below_midscale_returns_negative_current(void)
+{
+    /*
+     * ACS712: below 2.5V = negative current (charging/regen).
+     * At 2.0V: current = (2.0 - 2.5) / 0.1 = -5A
+     * ADC for 2.0V = (2.0 / 3.3) * 4095 = 2482
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_2, 2482U);
+
+    float result = sensor_read_current();
+
+    /* Should be ~-5A */
+    TEST_ASSERT_FLOAT_WITHIN(1.0f, -5.0f, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * VOLTAGE SENSOR TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_voltage_adc_zero_returns_zero_volts(void)
+{
+    mock_adc_set_channel_value(ADC_CHANNEL_3, 0U);
+
+    float result = sensor_read_voltage();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 0.0f, result);
+}
+
+void test_sensor_voltage_adc_fullscale_returns_expected_battery_voltage(void)
+{
+    /*
+     * ADC = 4095 → adc_voltage = 3.3V
+     * battery_V = 3.3V / 0.0909 = 36.3V
+     * (resistor divider: R1=100k, R2=10k → ratio = 10/110 = 0.0909)
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_3, 4095U);
+
+    float result = sensor_read_voltage();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 36.3f, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * THROTTLE TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_throttle_adc_zero_returns_zero_percent(void)
+{
+    mock_adc_set_channel_value(ADC_CHANNEL_4, 0U);
+
+    uint8_t result = sensor_read_throttle();
+
+    TEST_ASSERT_EQUAL_UINT8(0U, result);
+}
+
+void test_sensor_throttle_adc_fullscale_returns_100_percent(void)
+{
+    mock_adc_set_channel_value(ADC_CHANNEL_4, 4095U);
+
+    uint8_t result = sensor_read_throttle();
+
+    TEST_ASSERT_EQUAL_UINT8(100U, result);
+}
+
+void test_sensor_throttle_midscale_returns_50_percent(void)
+{
+    /* ADC = 2048 → (2048 * 100) / 4095 = 50% */
+    mock_adc_set_channel_value(ADC_CHANNEL_4, 2048U);
+
+    uint8_t result = sensor_read_throttle();
+
+    /* Accept 49 or 50 — integer division may round down */
+    TEST_ASSERT_TRUE((result == 49U) || (result == 50U));
+}
+
+void test_sensor_throttle_never_exceeds_100_percent(void)
+{
+    /*
+     * Inject a value slightly above 4095 by mocking 4095 max —
+     * the clamp in sensor_read_throttle() must catch any edge case.
+     */
+    mock_adc_set_channel_value(ADC_CHANNEL_4, 4095U);
+
+    uint8_t result = sensor_read_throttle();
+
+    TEST_ASSERT_TRUE(result <= 100U);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * BRAKE AND FAULT SWITCH TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_brake_gpio_low_returns_true_after_debounce(void)
+{
+    /*
+     * Active-low wiring: PB0 LOW = switch pressed = return true.
+     * We must advance simulated time past the debounce period.
+     */
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);  /* LOW = pressed */
+
+    /* First read — state just changed, debounce not yet passed */
+    mock_hal_set_tick(0U);
+    TEST_ASSERT_FALSE(sensor_read_brake());
+
+    /* Advance time past debounce period */
+    mock_hal_set_tick(EV_GPIO_DEBOUNCE_MS + 5U);
+    bool after_debounce = sensor_read_brake();
+
+    /* After debounce, should be true (pressed) */
+    TEST_ASSERT_TRUE(after_debounce);
+}
+
+void test_sensor_brake_gpio_high_returns_false(void)
+{
+    /* 1. First, set the brake to an ACTIVE state so we can test it turning OFF */
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET); // Pressed
+    mock_hal_set_tick(100);
+    (void)sensor_read_brake(); // Latch to TRUE
+
+    /* 2. Act: Release the switch (HIGH) */
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_0, GPIO_PIN_SET);   /* HIGH = released */
+
+    /* 3. MNC FIX: Advance virtual time past the debounce period (e.g., 50ms) */
+    mock_hal_set_tick(100 + EV_GPIO_DEBOUNCE_MS + 5U);
+
+    /* 4. Assert: Result should now be FALSE */
+    TEST_ASSERT_FALSE(sensor_read_brake());
+}
+
+void test_sensor_fault_switch_gpio_low_returns_true_after_debounce(void)
+{
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_1, GPIO_PIN_RESET);
+    mock_hal_set_tick(0U);
+    (void)sensor_read_fault_switch();   /* First read — start debounce */
+    mock_hal_set_tick(EV_GPIO_DEBOUNCE_MS + 5U);
+
+    bool result = sensor_read_fault_switch();
+
+    TEST_ASSERT_TRUE(result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * sensor_init() TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_init_null_adc_handle_returns_invalid(void)
+{
+    ev_status_t result = sensor_init(NULL, &s_test_htim);
+
+    TEST_ASSERT_EQUAL(EV_STATUS_INVALID, result);
+}
+
+void test_sensor_init_null_tim_handle_returns_invalid(void)
+{
+    ev_status_t result = sensor_init(&s_test_hadc, NULL);
+
+    TEST_ASSERT_EQUAL(EV_STATUS_INVALID, result);
+}
+
+void test_sensor_init_valid_handles_returns_ok(void)
+{
+    ev_status_t result = sensor_init(&s_test_hadc, &s_test_htim);
+
+    TEST_ASSERT_EQUAL(EV_STATUS_OK, result);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * sensor_read_all() TESTS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void test_sensor_read_all_null_pointer_returns_invalid(void)
+{
+    ev_status_t result = sensor_read_all(NULL);
+
+    TEST_ASSERT_EQUAL(EV_STATUS_INVALID, result);
+}
+
+void test_sensor_read_all_valid_pointer_populates_all_fields(void)
+{
+    sensor_data_t data;
+
+    /* Arrange: set all ADC channels to known values */
+    mock_adc_set_channel_value(ADC_CHANNEL_0, 620U);   /* ~50°C battery temp  */
+    mock_adc_set_channel_value(ADC_CHANNEL_1, 620U);   /* ~50°C motor temp    */
+    mock_adc_set_channel_value(ADC_CHANNEL_2, 3102U);  /* ~0A current         */
+    mock_adc_set_channel_value(ADC_CHANNEL_3, 0U);     /* 0V voltage          */
+    mock_adc_set_channel_value(ADC_CHANNEL_4, 0U);     /* 0% throttle         */
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_0, GPIO_PIN_SET);  /* Brake released     */
+    mock_gpio_set_pin(GPIOB, GPIO_PIN_1, GPIO_PIN_SET);  /* Fault sw released  */
+
+    /* Advance time to ensure the 'Released' state is processed by the debouncer */
+    mock_hal_set_tick(500);
+
+    /* Act */
+    ev_status_t status = sensor_read_all(&data);
+
+    /* Assert: function returned OK and fields are populated */
+    TEST_ASSERT_EQUAL(EV_STATUS_OK, status);
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 50.0f, data.batt_temp_c);
+    TEST_ASSERT_FLOAT_WITHIN(2.0f, 50.0f, data.motor_temp_c);
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 0.0f,  data.current_a);
+    TEST_ASSERT_EQUAL_UINT8(0U, data.throttle_pct);
+    TEST_ASSERT_FALSE(data.brake_active);
+    TEST_ASSERT_FALSE(data.fault_switch);
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Write 2–3 sentences. Be specific. -->
<!-- Example: "Implements the battery temperature ADC read function in sensor_hal.c.
              Adds unit tests for all boundary conditions. Updates the pin mapping table in Confluence." -->
Implements the full Sensor HAL module for Sprint 2. Adds `sensor_hal.c` and `sensor_hal.h` with ADC reads for battery temperature (LM35, CH0), motor temperature (LM35, CH1), battery current (ACS712-20A, CH2), battery voltage (resistor divider, CH3), and throttle position (potentiometer, CH4).

## Type of Change
<!-- Put an x inside the [ ] that applies: [x] -->
- [x] 🆕 New feature / user story
- [ ] 🐛 Bug fix
- [ ] ♻️  Refactor (no behaviour change)
- [ ] 📝 Documentation only
- [ ] 🔧 CI/CD or tooling change
- [ ] 🔒 Security fix

## Related Issue
<!-- Every PR must be linked to a GitHub Issue -->
Closes #23 #22 #24 #25 #26 #27 #28 

## Changes Made
<!-- List every significant change. Be specific so the reviewer knows what to look at. -->
- Added `core/src/sensor_hal.c` - full implementation of all 8 sensor read functions plus `sensor_init()`, `sensor_read_all()`, `sensor_enable_i2c_temp()` (stub), and `sensor_get_temp_backend()`
- Added `core/inc/sensor_hal.h` - public interface with Doxygen comments for every function, including Sprint 5 I2C preparation stubs
- Updated `drivers/STM32_HAL/stm32_stubs.c` - added stub implementations for all HAL GPIO, ADC, and timer functions used by the sensor module
- Added `tests/test_sensor_hal.c` - 22 unit tests covering all sensor read functions, boundary conditions, null pointer guards, ADC channel isolation, and GPIO debounce logic
- Added `tests/mocks/mock_stm32_hal_adc.c/.h` - full mock with per-channel value injection, start error, and poll timeout injection
- Added `tests/mocks/mock_stm32_hal_gpio.c/.h` - full mock with per-pin state control and `mock_hal_set_tick()` for debounce testing
- Added `tests/mocks/mock_stm32_hal_tim.c/.h` - mock with encoder count injection, ARR/CCR1 access, and PWM start error injection

## How to Test This PR
<!-- Step-by-step instructions for the reviewer to verify this works -->
1. Clone the branch: `git checkout feat/sensor-hal`
2. Build the test suite: `cd tests && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && make`

## Testing Done by Author
<!-- Check all that apply -->
- [x] Unit tests written for new/changed code
- [x] All existing tests pass locally (`cd Tests/build && ./test_runner` → 0 Failures)
- [x] Cppcheck passes locally (`cppcheck --error-exitcode=1 -I core/Inc core/src/`)
- [x] Code compiled successfully (`cmake --build build`)
- [ ] Tested in Wokwi simulation (if applicable)
- [ ] UART output verified (if applicable)
- [x] No new compiler warnings (`-Wall -Wextra` clean)

## Code Quality Checklist
<!-- Check all that apply. Do NOT open a PR without completing this. -->
- [x] Code follows naming conventions from `06_CODING_STANDARDS.md`
- [x] All public functions have Doxygen-style comments (`@brief`, `@param`, `@retval`)
- [x] No magic numbers — all constants are in `ev_config.h`
- [x] All function parameters are validated (null checks where applicable)
- [x] Return values of all called functions are checked
- [x] All `switch` statements have a `default` case
- [x] All `if/for/while` blocks use `{` braces even for single lines

## Documentation
- [ ] `README.md` updated if new setup steps are needed
- [ ] Inline `/* TODO: */` comments added for any deferred work

---
<!-- Do not edit below this line -->
**Reviewer checklist:**
- [x] Code logic is correct and matches the linked issue requirements
- [x] Tests are meaningful (not just "assert(1 == 1)")
- [x] No obvious security or safety issues
- [x] Comments are clear and accurate
