### PR TITLE
feat(fault-manager): implement threshold checks, fault bitmask and 20 unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(FIRMWARE_SOURCES
     core/src/sensor_hal.c
     core/src/motor_ctrl.c
     core/src/fault_logger.c
-    # core/src/can_driver.c
+    core/src/fault_manager.c
     # core/src/logger.c
     # core/src/ev_state_machine.c
     drivers/STM32_HAL/stm32_stubs.c

--- a/core/inc/fault_manager.h
+++ b/core/inc/fault_manager.h
@@ -1,0 +1,115 @@
+/**
+ * @file    fault_manager.h
+ * @brief   Fault Manager - threshold checking and fault code management
+ *
+ * @details This module is responsible for comparing all sensor readings
+ *          against configured thresholds (ev_config.h) and building the
+ *          active fault bitmask. It is the ONLY module allowed to set
+ *          fault codes - all other modules read them.
+ *
+ *          Fault bits are defined in ev_types.h:
+ *            FAULT_OVER_TEMP_BATT  = 0x01
+ *            FAULT_OVER_TEMP_MOTOR = 0x02
+ *            FAULT_OVER_CURRENT    = 0x04
+ *            FAULT_UNDER_VOLTAGE   = 0x08
+ *            FAULT_OVER_VOLTAGE    = 0x10
+ *            FAULT_WATCHDOG        = 0x20
+ *            FAULT_CAN_ERROR       = 0x40
+ *            FAULT_MANUAL_TRIGGER  = 0x80
+ *
+ *          Typical call sequence in main loop (Sprint 3):
+ *          @code
+ *            sensor_read_all(&g_sensor_data);
+ *            fault_code_t faults = fault_check_all(&g_sensor_data);
+ *            ev_sm_set_fault(faults);
+ *          @endcode
+ *
+ *          Design rule: fault_check_all() NEVER modifies global state.
+ *          It only reads the sensor data passed in and returns a bitmask.
+ *          This makes it trivially testable - no setUp/tearDown needed.
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2026
+ */
+
+#ifndef FAULT_MANAGER_H
+#define FAULT_MANAGER_H
+
+/* --- Includes --------------------------------------------------------- */
+#include <stdint.h>
+#include <stddef.h>
+#include "ev_types.h"
+#include "ev_config.h"
+
+/* --- Public Function Declarations --------------------------------------- */
+
+/**
+ * @brief  Check all sensor readings against configured fault thresholds.
+ *
+ * @details Evaluates every threshold defined in ev_config.h and sets the
+ *          corresponding bit in the returned fault_code_t bitmask.
+ *
+ *          Checks performed:
+ *            1. batt_temp_c   > EV_BATT_TEMP_CRITICAL_C  -> FAULT_OVER_TEMP_BATT
+ *            2. motor_temp_c  > EV_MOTOR_TEMP_CRITICAL_C -> FAULT_OVER_TEMP_MOTOR
+ *            3. current_a     > EV_CURRENT_CRITICAL_A    -> FAULT_OVER_CURRENT
+ *            4. voltage_v     < EV_VOLTAGE_MIN_CRITICAL_V -> FAULT_UNDER_VOLTAGE
+ *            5. voltage_v     > EV_VOLTAGE_MAX_CRITICAL_V -> FAULT_OVER_VOLTAGE
+ *            6. fault_switch  == true                     -> FAULT_MANUAL_TRIGGER
+ *
+ *          All 6 checks are always evaluated - no early return on first fault.
+ *          This ensures the complete fault picture is captured in one call.
+ *
+ *          This function is PURE - it has no side effects, no global reads or
+ *          writes. Same inputs always produce the same output. Unit-testable
+ *          with zero mocking required.
+ *
+ * @param  data  Pointer to sensor data snapshot. Must not be NULL.
+ *               All fields of sensor_data_t are evaluated.
+ *
+ * @retval Bitmask of all active faults. FAULT_NONE (0x00) = no faults.
+ *         If data == NULL, returns FAULT_INVALID_DATA (0xFF) — treat
+ *         as a critical error and enter SAFE_STATE immediately.
+ */
+fault_code_t fault_check_all(const sensor_data_t *data);
+
+/**
+ * @brief  Check if a specific fault bit is set in a fault code.
+ *
+ * @details Convenience wrapper for bitmask operations. Avoids magic bitwise
+ *          operations scattered through calling code.
+ *
+ *          Example:
+ *          @code
+ *            fault_code_t faults = fault_check_all(&data);
+ *            if (fault_is_set(faults, FAULT_OVER_TEMP_BATT)) {
+ *                // Battery temperature fault handling
+ *            }
+ *          @endcode
+ *
+ * @param  faults    Fault bitmask returned by fault_check_all().
+ * @param  fault_bit Specific fault bit to check (e.g., FAULT_OVER_CURRENT).
+ *
+ * @retval true  The specified fault bit is set.
+ * @retval false The specified fault bit is clear, or faults == FAULT_NONE.
+ */
+bool fault_is_set(fault_code_t faults, fault_code_t fault_bit);
+
+/**
+ * @brief  Return a human-readable string for a fault code.
+ *
+ * @details Returns the name of the HIGHEST-PRIORITY active fault in
+ *          the bitmask. Priority order matches bit significance (LSB first).
+ *          Used for UART diagnostic logging in main loop.
+ *
+ *          Example output: "OVER_TEMP_BATT", "OVER_CURRENT", "NONE"
+ *
+ * @param  faults  Fault bitmask to decode.
+ *
+ * @retval Pointer to a constant string literal. Never NULL.
+ *         Do NOT free() the returned pointer.
+ */
+const char *fault_get_name(fault_code_t faults);
+
+#endif /* FAULT_MANAGER_H */

--- a/core/src/fault_manager.c
+++ b/core/src/fault_manager.c
@@ -1,0 +1,130 @@
+/**
+ * @file    fault_manager.c
+ * @brief   Fault Manager - threshold checking and fault bitmask construction
+ *
+ * @details This module evaluates every fault
+ *          threshold from ev_config.h against the sensor data snapshot
+ *          passed in and returns a bitmask of all active faults.
+ *
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2026
+ */
+
+/* --- Includes --------------------------------------------------------------- */
+#include "fault_manager.h"
+#include <stddef.h>
+
+/* --- Private Helper Macro --------------------------------------------------- */
+
+/**
+ * @brief  Set a fault bit in a bitmask if a condition is true.
+ *
+ * @details Using a macro avoids repeating the if/set pattern 6 times.
+ *          It is not a function because we want it inlined with zero overhead.
+ *          The parentheses around all arguments prevent operator precedence bugs.
+ */
+#define SET_FAULT_IF(condition, mask, bit)  \
+    do {                                    \
+        if ((condition))                    \
+        {                                   \
+            (mask) |= (bit);                \
+        }                                   \
+    } while (0)
+
+/* --- Public Function Implementations --------------------------------------------- */
+
+/**
+ * @brief  Check all sensor readings against fault thresholds.
+ */
+fault_code_t fault_check_all(const sensor_data_t *data)
+{
+    fault_code_t code = FAULT_NONE;
+
+    /* NULL data is a critical error — we cannot make safe decisions */
+    if (data == NULL)
+    {
+        return FAULT_INVALID_DATA;
+    }
+
+    /*
+     * Check 1 - Battery over-temperature
+     * Threshold: EV_BATT_TEMP_CRITICAL_C = 60.0°C
+     * Source: ev_config.h Section 1
+     */
+    SET_FAULT_IF(data->batt_temp_c > EV_BATT_TEMP_CRITICAL_C,
+                 code, FAULT_OVER_TEMP_BATT);
+
+    /*
+     * Check 2 - Motor over-temperature
+     * Threshold: EV_MOTOR_TEMP_CRITICAL_C = 80.0°C
+     * Motors tolerate higher temperatures than Li-ion battery cells.
+     */
+    SET_FAULT_IF(data->motor_temp_c > EV_MOTOR_TEMP_CRITICAL_C,
+                 code, FAULT_OVER_TEMP_MOTOR);
+
+    /*
+     * Check 3 - Over-current
+     * Threshold: EV_CURRENT_CRITICAL_A = 50.0A
+     * Positive = discharge direction. Negative current (charging) is not a fault.
+     */
+    SET_FAULT_IF(data->current_a > EV_CURRENT_CRITICAL_A,
+                 code, FAULT_OVER_CURRENT);
+
+    /*
+     * Check 4 - Under-voltage
+     * Threshold: EV_VOLTAGE_MIN_CRITICAL_V = 35.0V
+     * Below this level the battery may be permanently damaged.
+     */
+    SET_FAULT_IF(data->voltage_v < EV_VOLTAGE_MIN_CRITICAL_V,
+                 code, FAULT_UNDER_VOLTAGE);
+
+    /*
+     * Check 5 - Over-voltage
+     * Threshold: EV_VOLTAGE_MAX_CRITICAL_V = 55.0V
+     * Indicates charging failure or regenerative braking overcurrent.
+     */
+    SET_FAULT_IF(data->voltage_v > EV_VOLTAGE_MAX_CRITICAL_V,
+                 code, FAULT_OVER_VOLTAGE);
+
+    /*
+     * Check 6 - Manual fault trigger
+     * The physical fault switch on PB1 allows engineers to manually
+     * inject a fault during testing to verify the fault response chain.
+     */
+    SET_FAULT_IF(data->fault_switch == true,
+                 code, FAULT_MANUAL_TRIGGER);
+
+    return code;
+}
+
+/**
+ * @brief  Check if a specific fault bit is set in a fault bitmask.
+ */
+bool fault_is_set(fault_code_t faults, fault_code_t fault_bit)
+{
+    return ((faults & fault_bit) != FAULT_NONE);
+}
+
+/**
+ * @brief  Return a human-readable name for the active fault.
+ */
+const char *fault_get_name(fault_code_t faults)
+{
+    /*
+     * Check in priority order — lowest bit first (most safety-critical).
+     * Returns the name of the FIRST (highest-priority) active fault.
+     * If multiple faults are active, the caller should log them individually.
+     */
+    if (faults == FAULT_NONE)          { return "NONE"; }
+    if (fault_is_set(faults, FAULT_OVER_TEMP_BATT))   { return "OVER_TEMP_BATT"; }
+    if (fault_is_set(faults, FAULT_OVER_TEMP_MOTOR))  { return "OVER_TEMP_MOTOR"; }
+    if (fault_is_set(faults, FAULT_OVER_CURRENT))     { return "OVER_CURRENT"; }
+    if (fault_is_set(faults, FAULT_UNDER_VOLTAGE))    { return "UNDER_VOLTAGE"; }
+    if (fault_is_set(faults, FAULT_OVER_VOLTAGE))     { return "OVER_VOLTAGE"; }
+    if (fault_is_set(faults, FAULT_WATCHDOG))         { return "WATCHDOG"; }
+    if (fault_is_set(faults, FAULT_CAN_ERROR))        { return "CAN_ERROR"; }
+    if (fault_is_set(faults, FAULT_MANUAL_TRIGGER))   { return "MANUAL_TRIGGER"; }
+    return "UNKNOWN";
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ set(FIRMWARE_SOURCES_UNDER_TEST
     ../core/src/sensor_hal.c
     ../core/src/motor_ctrl.c
     ../core/src/fault_logger.c
-    # ../core/src/can_driver.c     - Add in Sprint 3
+    ../core/src/fault_manager.c
     # ../core/src/logger.c         - Add in Sprint 4
     # ../core/src/ev_state_machine.c - Add in Sprint 4
 )
@@ -77,6 +77,7 @@ set(TEST_SOURCES
     test_sensor_hal.c
     test_motor_ctrl.c
     test_protocol_prep.c
+    test_fault_manager.c
     # test_can_driver.c     - Add in Sprint 3
     # test_ev_state_machine.c - Add in Sprint 4
     test_runner.c

--- a/tests/test_fault_manager.c
+++ b/tests/test_fault_manager.c
@@ -1,0 +1,277 @@
+/**
+ * @file    test_fault_manager.c
+ * @brief   Unit tests for fault_manager.c
+ *
+ * @details Tests for all fault threshold checks in fault_check_all(),
+ *          fault_is_set(), and fault_get_name().
+ *
+ *          No mocks required - fault_check_all() is a pure function that
+ *          only reads the sensor_data_t passed in. setUp()/tearDown() are
+ *          kept minimal.
+ *
+ *          Total tests: 20
+ *
+ * @author  BaseSync Team
+ * @version 1.0
+ * @date    2026
+ */
+
+#include "Unity/unity.h"
+#include "ev_types.h"
+#include "ev_config.h"
+#include "fault_manager.h"
+
+/* --- Test fixture helpers --------------------------------------------------- */
+
+/**
+ * @brief  Return a sensor_data_t with all values in the SAFE (no-fault) range.
+ *
+ * @details Used as the baseline for all tests - each test modifies only
+ *          the field under test. This ensures tests are isolated.
+ */
+static sensor_data_t make_safe_data(void)
+{
+    sensor_data_t d;
+
+    d.batt_temp_c  = 25.0f;   /* Room temperature - well below 60°C */
+    d.motor_temp_c = 30.0f;   /* Well below 80°C */
+    d.current_a    = 10.0f;   /* Well below 50A */
+    d.voltage_v    = 48.0f;   /* Nominal pack voltage - between 35V and 55V */
+    d.speed_rpm    = 0U;
+    d.throttle_pct = 0U;
+    d.brake_active = false;
+    d.fault_switch = false;
+
+    return d;
+}
+
+/* --- setUp / tearDown ------------------------------------------------------ */
+
+void fm_setUp(void)
+{
+    /* No module state to reset - fault_manager is stateless */
+}
+
+void fm_tearDown(void)
+{
+    /* Nothing to tear down */
+}
+
+/* --- Tests: NULL pointer guard ------------------------------------------------ */
+
+void test_fault_check_null_data_returns_fault_invalid_data(void)
+{
+    fault_code_t result = fault_check_all(NULL);
+
+    TEST_ASSERT_EQUAL_HEX8(FAULT_INVALID_DATA, result);
+}
+
+/* --- Tests: No-fault baseline ------------------------------------------------ */
+
+void test_fault_check_all_safe_data_returns_fault_none(void)
+{
+    sensor_data_t data = make_safe_data();
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_EQUAL_HEX8(FAULT_NONE, result);
+}
+
+/* --- Tests: Battery over-temperature --------------------------------------- */
+
+void test_fault_check_batt_temp_below_threshold_no_fault(void)
+{
+    sensor_data_t data    = make_safe_data();
+    data.batt_temp_c      = EV_BATT_TEMP_CRITICAL_C - 0.1f;   /* Just under */
+
+    fault_code_t result   = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_OVER_TEMP_BATT));
+}
+
+void test_fault_check_batt_temp_at_threshold_no_fault(void)
+{
+    /*
+     * Threshold is STRICTLY greater than (>), not >=.
+     * Exactly at threshold must NOT trigger fault.
+     */
+    sensor_data_t data    = make_safe_data();
+    data.batt_temp_c      = EV_BATT_TEMP_CRITICAL_C;   /* Exactly at limit */
+
+    fault_code_t result   = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_OVER_TEMP_BATT));
+}
+
+void test_fault_check_batt_temp_above_threshold_sets_bit(void)
+{
+    sensor_data_t data    = make_safe_data();
+    data.batt_temp_c      = EV_BATT_TEMP_CRITICAL_C + 0.1f;   /* Just over */
+
+    fault_code_t result   = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_TEMP_BATT));
+}
+
+/* --- Tests: Motor over-temperature ------------------------------------------------ */
+
+void test_fault_check_motor_temp_above_threshold_sets_bit(void)
+{
+    sensor_data_t data    = make_safe_data();
+    data.motor_temp_c     = EV_MOTOR_TEMP_CRITICAL_C + 0.1f;
+
+    fault_code_t result   = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_TEMP_MOTOR));
+}
+
+void test_fault_check_motor_temp_at_threshold_no_fault(void)
+{
+    sensor_data_t data    = make_safe_data();
+    data.motor_temp_c     = EV_MOTOR_TEMP_CRITICAL_C;
+
+    fault_code_t result   = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_OVER_TEMP_MOTOR));
+}
+
+/* --- Tests: Over-current ------------------------------------------------ */
+
+void test_fault_check_over_current_above_threshold_sets_bit(void)
+{
+    sensor_data_t data  = make_safe_data();
+    data.current_a      = EV_CURRENT_CRITICAL_A + 0.1f;
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_CURRENT));
+}
+
+void test_fault_check_negative_current_no_fault(void)
+{
+    /* Negative current = charging. Not a fault. */
+    sensor_data_t data  = make_safe_data();
+    data.current_a      = -5.0f;
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_OVER_CURRENT));
+}
+
+/* --- Tests: Under-voltage ------------------------------------------------ */
+
+void test_fault_check_under_voltage_below_threshold_sets_bit(void)
+{
+    sensor_data_t data  = make_safe_data();
+    data.voltage_v      = EV_VOLTAGE_MIN_CRITICAL_V - 0.1f;
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_UNDER_VOLTAGE));
+}
+
+void test_fault_check_voltage_at_min_threshold_no_fault(void)
+{
+    sensor_data_t data  = make_safe_data();
+    data.voltage_v      = EV_VOLTAGE_MIN_CRITICAL_V;   /* Exactly at limit */
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_UNDER_VOLTAGE));
+}
+
+/* --- Tests: Over-voltage --------------------------------------------------- */
+
+void test_fault_check_over_voltage_above_threshold_sets_bit(void)
+{
+    sensor_data_t data  = make_safe_data();
+    data.voltage_v      = EV_VOLTAGE_MAX_CRITICAL_V + 0.1f;
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_VOLTAGE));
+}
+
+void test_fault_check_voltage_at_max_threshold_no_fault(void)
+{
+    sensor_data_t data  = make_safe_data();
+    data.voltage_v      = EV_VOLTAGE_MAX_CRITICAL_V;
+
+    fault_code_t result = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_OVER_VOLTAGE));
+}
+
+/* --- Tests: Manual fault trigger ------------------------------------------------ */
+
+void test_fault_check_fault_switch_pressed_sets_manual_trigger(void)
+{
+    sensor_data_t data   = make_safe_data();
+    data.fault_switch    = true;
+
+    fault_code_t result  = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_MANUAL_TRIGGER));
+}
+
+void test_fault_check_fault_switch_not_pressed_no_manual_trigger(void)
+{
+    sensor_data_t data   = make_safe_data();
+    data.fault_switch    = false;
+
+    fault_code_t result  = fault_check_all(&data);
+
+    TEST_ASSERT_FALSE(fault_is_set(result, FAULT_MANUAL_TRIGGER));
+}
+
+/* --- Tests: Multiple simultaneous faults --------------------------------------- */
+
+void test_fault_check_multiple_faults_all_bits_set(void)
+{
+    sensor_data_t data   = make_safe_data();
+    data.batt_temp_c     = EV_BATT_TEMP_CRITICAL_C  + 1.0f;
+    data.motor_temp_c    = EV_MOTOR_TEMP_CRITICAL_C + 1.0f;
+    data.current_a       = EV_CURRENT_CRITICAL_A    + 1.0f;
+    data.fault_switch    = true;
+
+    fault_code_t result  = fault_check_all(&data);
+
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_TEMP_BATT));
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_TEMP_MOTOR));
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_OVER_CURRENT));
+    TEST_ASSERT_TRUE(fault_is_set(result, FAULT_MANUAL_TRIGGER));
+}
+
+/* --- Tests: fault_is_set() helper --------------------------------------- */
+
+void test_fault_is_set_returns_false_for_clear_bit(void)
+{
+    fault_code_t faults = FAULT_OVER_CURRENT;   /* Only bit 2 set */
+
+    TEST_ASSERT_FALSE(fault_is_set(faults, FAULT_OVER_TEMP_BATT));
+}
+
+void test_fault_is_set_returns_true_for_set_bit(void)
+{
+    fault_code_t faults = FAULT_OVER_CURRENT;
+
+    TEST_ASSERT_TRUE(fault_is_set(faults, FAULT_OVER_CURRENT));
+}
+
+/* --- Tests: fault_get_name() --------------------------------------- */
+
+void test_fault_get_name_returns_none_for_no_fault(void)
+{
+    const char *name = fault_get_name(FAULT_NONE);
+
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("NONE", name);
+}
+
+void test_fault_get_name_returns_correct_name_for_over_temp_batt(void)
+{
+    const char *name = fault_get_name(FAULT_OVER_TEMP_BATT);
+
+    TEST_ASSERT_NOT_NULL(name);
+    TEST_ASSERT_EQUAL_STRING("OVER_TEMP_BATT", name);
+}

--- a/tests/test_runner.c
+++ b/tests/test_runner.c
@@ -108,6 +108,28 @@ extern void test_i2c_tmp102_8bit_address_is_7bit_shifted(void);
 extern void test_spi_flash_log_max_entries_matches_area_size(void);
 extern void test_spi_flash_sector_size_divides_log_size_evenly(void);
 
+/* --- Sprint 3: Fault Manager tests ------------------------------------------ */
+extern void test_fault_check_null_data_returns_fault_invalid_data(void);
+extern void test_fault_check_all_safe_data_returns_fault_none(void);
+extern void test_fault_check_batt_temp_below_threshold_no_fault(void);
+extern void test_fault_check_batt_temp_at_threshold_no_fault(void);
+extern void test_fault_check_batt_temp_above_threshold_sets_bit(void);
+extern void test_fault_check_motor_temp_above_threshold_sets_bit(void);
+extern void test_fault_check_motor_temp_at_threshold_no_fault(void);
+extern void test_fault_check_over_current_above_threshold_sets_bit(void);
+extern void test_fault_check_negative_current_no_fault(void);
+extern void test_fault_check_under_voltage_below_threshold_sets_bit(void);
+extern void test_fault_check_voltage_at_min_threshold_no_fault(void);
+extern void test_fault_check_over_voltage_above_threshold_sets_bit(void);
+extern void test_fault_check_voltage_at_max_threshold_no_fault(void);
+extern void test_fault_check_fault_switch_pressed_sets_manual_trigger(void);
+extern void test_fault_check_fault_switch_not_pressed_no_manual_trigger(void);
+extern void test_fault_check_multiple_faults_all_bits_set(void);
+extern void test_fault_is_set_returns_false_for_clear_bit(void);
+extern void test_fault_is_set_returns_true_for_set_bit(void);
+extern void test_fault_get_name_returns_none_for_no_fault(void);
+extern void test_fault_get_name_returns_correct_name_for_over_temp_batt(void);
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -195,6 +217,28 @@ int main(void)
     RUN_TEST(test_i2c_tmp102_8bit_address_is_7bit_shifted);
     RUN_TEST(test_spi_flash_log_max_entries_matches_area_size);
     RUN_TEST(test_spi_flash_sector_size_divides_log_size_evenly);
+
+    /* --- Sprint 3: Fault Manager --- */
+    RUN_TEST(test_fault_check_null_data_returns_fault_invalid_data);
+    RUN_TEST(test_fault_check_all_safe_data_returns_fault_none);
+    RUN_TEST(test_fault_check_batt_temp_below_threshold_no_fault);
+    RUN_TEST(test_fault_check_batt_temp_at_threshold_no_fault);
+    RUN_TEST(test_fault_check_batt_temp_above_threshold_sets_bit);
+    RUN_TEST(test_fault_check_motor_temp_above_threshold_sets_bit);
+    RUN_TEST(test_fault_check_motor_temp_at_threshold_no_fault);
+    RUN_TEST(test_fault_check_over_current_above_threshold_sets_bit);
+    RUN_TEST(test_fault_check_negative_current_no_fault);
+    RUN_TEST(test_fault_check_under_voltage_below_threshold_sets_bit);
+    RUN_TEST(test_fault_check_voltage_at_min_threshold_no_fault);
+    RUN_TEST(test_fault_check_over_voltage_above_threshold_sets_bit);
+    RUN_TEST(test_fault_check_voltage_at_max_threshold_no_fault);
+    RUN_TEST(test_fault_check_fault_switch_pressed_sets_manual_trigger);
+    RUN_TEST(test_fault_check_fault_switch_not_pressed_no_manual_trigger);
+    RUN_TEST(test_fault_check_multiple_faults_all_bits_set);
+    RUN_TEST(test_fault_is_set_returns_false_for_clear_bit);
+    RUN_TEST(test_fault_is_set_returns_true_for_set_bit);
+    RUN_TEST(test_fault_get_name_returns_none_for_no_fault);
+    RUN_TEST(test_fault_get_name_returns_correct_name_for_over_temp_batt);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Write 2–3 sentences. Be specific. -->
<!-- Example: "Implements the battery temperature ADC read function in sensor_hal.c.
              Adds unit tests for all boundary conditions." -->
Implements the fault manager module for Sprint 3 (S3-01, S3-05). Creates fault_manager.h and fault_manager.c with a pure function that checks all 6 sensor thresholds and returns a fault bitmask. Adds 20 unit tests covering every threshold boundary, NULL input, multiple simultaneous faults, and helper functions. Total test count moves  89.

## Type of Change
<!-- Put an x inside the [ ] that applies: [x] -->
- [x] 🆕 New feature / user story
- [ ] 🐛 Bug fix
- [ ] ♻️  Refactor (no behaviour change)
- [ ] 📝 Documentation only
- [ ] 🔧 CI/CD or tooling change
- [ ] 🔒 Security fix

## Related Issue
<!-- Every PR must be linked to a GitHub Issue -->
Closes #42 #46 

## Changes Made
<!-- List every significant change. Be specific so the reviewer knows what to look at. -->
- `core/inc/fault_manager.h` - public API: `fault_check_all()`,  `fault_is_set()`, `fault_get_name()`
- `core/src/fault_manager.c` - implementation: pure function, SET_FAULT_IF macro, all 6 threshold checks, NULL guard returns FAULT_INVALID_DATA (0xFF)
- `tests/test_fault_manager.c` - 20 unit tests covering all boundaries, NULL input, simultaneous faults, fault_is_set(), fault_get_name()
- `tests/test_runner.c` - updated with extern declarations and RUN_TEST() calls for all 20 new tests
- `CMakeLists.txt` - fault_manager.c added to FIRMWARE_SOURCES - `tests/CMakeLists.txt` - fault_manager.c added to FIRMWARE_SOURCES_UNDER_TEST, test_fault_manager.c added to TEST_SOURCES

## How to Test This PR
<!-- Step-by-step instructions for the reviewer to verify this works -->
1. Checkout this branch and navigate to repo root
2. Run cmake test comamnd - verify output ends with 
   `89 Tests, 0 Failures, 0 Ignored — OK`
3. Run build command - verify size output appears with 0 errors, 0 warnings
4. Run cppcheck command - verify no findings on fault_manager.c
5. Open `tests/test_fault_manager.c` and review boundary tests - each threshold has three cases: just below (no fault), at exactly (no fault), just above (fault)

## Testing Done by Author
<!-- Check all that apply -->
- [x] Unit tests written for new/changed code
- [x] All existing tests pass locally (`cd Tests/build && ./test_runner` → 0 Failures)
- [x] Cppcheck passes locally (`cppcheck --error-exitcode=1 -I core/Inc core/src/`)
- [x] Code compiled successfully (`cmake --build build`)
- [ ] Tested in Wokwi simulation (if applicable)
- [ ] UART output verified (if applicable)
- [x] No new compiler warnings (`-Wall -Wextra` clean)

## Code Quality Checklist
<!-- Check all that apply. Do NOT open a PR without completing this. -->
- [x] Code follows naming conventions from `06_CODING_STANDARDS.md`
- [x] All public functions have Doxygen-style comments (`@brief`, `@param`, `@retval`)
- [x] No magic numbers - all constants are in `ev_config.h`
- [x] All function parameters are validated (null checks where applicable)
- [x] Return values of all called functions are checked
- [x] All `switch` statements have a `default` case
- [x] All `if/for/while` blocks use `{` braces even for single lines

## Documentation
- [ ] Docs folder updated if module interface or design changed
- [ ] `README.md` updated if new setup steps are needed
- [ ] Inline `/* TODO: */` comments added for any deferred work

## Screenshots / Logs (if applicable)
<!-- Paste UART output, simulation screenshots, or CI output that shows it working -->
```
-----------------------
89 Tests, 0 Failures, 0 Ignored
OK

make build:
   text    data     bss     dec     hex filename
   8158     124     488    8770    2242 ev-ecu-system.elf
[100%] Built target ev-ecu-system
```

---
<!-- Do not edit below this line -->
**Reviewer checklist:**
- [ ] Code logic is correct and matches the linked issue requirements
- [ ] Tests are meaningful (not just "assert(1 == 1)")
- [ ] No obvious security or safety issues
- [ ] Comments are clear and accurate
